### PR TITLE
Allow certain steps of a release to fail when the workflow is triggered manually

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -39,7 +39,7 @@ jobs:
           wapm login ${{ secrets.WAPM_DEV_TOKEN }}
       - name: Publish to wapm.dev
         run: cargo wapm --workspace
-        continue-on-error: ${{ github.event_name == "workflow_dispatch" }}
+        continue-on-error: ${{ github.event_name == 'workflow_dispatch' }}
       - name: Update the bindings generator on wapm.dev
         uses: actions-rs/cargo@v1
         with:
@@ -50,7 +50,7 @@ jobs:
           TOKEN: ${{ secrets.WAPM_DEV_TOKEN }}
           VERSION: latest
           RUST_LOG: info,xtask=debug
-        continue-on-error: ${{ github.event_name == "workflow_dispatch" }}
+        continue-on-error: ${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Login to wapm.io
         run: |
@@ -58,7 +58,7 @@ jobs:
           wapm login ${{ secrets.WAPM_PROD_TOKEN }}
       - name: Publish to wapm.io
         run: cargo wapm --workspace
-        continue-on-error: ${{ github.event_name == "workflow_dispatch" }}
+        continue-on-error: ${{ github.event_name == 'workflow_dispatch' }}
       - name: Update the bindings generator on wapm.io
         uses: actions-rs/cargo@v1
         with:
@@ -70,4 +70,4 @@ jobs:
           VERSION: latest
           COMMAND: wasmer-pack
           RUST_LOG: info,xtask=debug
-        continue-on-error: ${{ github.event_name == "workflow_dispatch" }}
+        continue-on-error: ${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -39,6 +39,7 @@ jobs:
           wapm login ${{ secrets.WAPM_DEV_TOKEN }}
       - name: Publish to wapm.dev
         run: cargo wapm --workspace
+        continue-on-error: ${{ github.event_name == "workflow_dispatch" }}
       - name: Update the bindings generator on wapm.dev
         uses: actions-rs/cargo@v1
         with:
@@ -49,6 +50,7 @@ jobs:
           TOKEN: ${{ secrets.WAPM_DEV_TOKEN }}
           VERSION: latest
           RUST_LOG: info,xtask=debug
+        continue-on-error: ${{ github.event_name == "workflow_dispatch" }}
 
       - name: Login to wapm.io
         run: |
@@ -56,6 +58,7 @@ jobs:
           wapm login ${{ secrets.WAPM_PROD_TOKEN }}
       - name: Publish to wapm.io
         run: cargo wapm --workspace
+        continue-on-error: ${{ github.event_name == "workflow_dispatch" }}
       - name: Update the bindings generator on wapm.io
         uses: actions-rs/cargo@v1
         with:
@@ -67,5 +70,4 @@ jobs:
           VERSION: latest
           COMMAND: wasmer-pack
           RUST_LOG: info,xtask=debug
-        # The mutation isn't available on prod yet
-        continue-on-error: true
+        continue-on-error: ${{ github.event_name == "workflow_dispatch" }}


### PR DESCRIPTION
This modifies `release.yml` so that publishing to WAPM may fail when the release workflow is triggered manually (i.e. `workflow_dispatch`).

This lets developers manually retry a release and "skip" (i.e. not error out) on when you get a *"wasmer/wasmer-pack v1.2.3 has already been published"* error.

You still need to keep an eye on the release job to make sure packages really were published successfully, but at least now there is an escape hatch for dealing with WAPM auth issues (e.g. if the `WAPM_PROD_TOKEN` secret is no longer accessible).