### PR TITLE
Moved time reporting to its own job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,10 +54,17 @@ jobs:
         with:
           command: test
           args: --workspace --verbose --locked
+
+  workflow-times:
+    name: Compile and Test
+    runs-on: ubuntu-latest
+    needs: check
+    steps:
       - name: Time Reporter
         uses: Michael-F-Bryan/workflow-timer@v0.1.5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          jobs: check
 
   lints:
     name: Linting and Formatting


### PR DESCRIPTION
## Description

I've reworked how the `Michael-F-Bryan/workflow-timer` action works and the comments it generates to be a bit more useful. 

I've also pulled the action out into its own job so it is measuring the full time for each job in the current workflow run. Before it counting the "current run time" as the time between the `check` run starting and when the action was triggered, and the "master run time" was the time between the `check` run starting and the end of the `check` run (i.e. after the action had been triggered and finished).

## Context

As part of the [Fast Compile Times](https://github.com/wasmerio/wasmer-pack/blob/bdfd5c9483821651cf0bbd70189fc04416bc22b1/CONTRIBUTING.md#goal-1-fast-compile-times) goal, we use the `Michael-F-Bryan/workflow-timer` action to make sure PR authors are aware of how long each CI run takes compared to the `master` branch.