### PR TITLE
Rename the "js" subcommand to "javascript" and add a "js" alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ change, where applicable.
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- Renamed `wasmer-pack`'s sub-commands to be called `javascript` and `python`,
+  with `js` and `py` as aliases (i.e. running `wasmer-pack js` is equivalent to
+  `wasmer-pack javascript`)
+  [#111](https://github.com/wasmerio/wasmer-pack/pull/111)
+
 ## [0.5.3] - 2022-12-02
 
 ### Fixed

--- a/crates/cli/src/bin/wasmer-pack.rs
+++ b/crates/cli/src/bin/wasmer-pack.rs
@@ -6,7 +6,7 @@ fn main() -> Result<(), Error> {
     let cmd = Cmd::parse();
 
     match cmd {
-        Cmd::Js(js) => js.run(Language::JavaScript),
+        Cmd::JavaScript(js) => js.run(Language::JavaScript),
         Cmd::Python(py) => py.run(Language::Python),
         Cmd::Show(show) => show.run(),
     }
@@ -16,8 +16,10 @@ fn main() -> Result<(), Error> {
 #[clap(version)]
 enum Cmd {
     /// Generate bindings for use with NodeJS.
-    Js(Codegen),
+    #[clap(name = "javascript", alias = "js")]
+    JavaScript(Codegen),
     /// Generate Python bindings.
+    #[clap(alias = "py")]
     Python(Codegen),
     /// Show metadata for the bindings that would be generated from a Pirita
     /// file.


### PR DESCRIPTION
## Description

This makes the CLI a bit more consistent by using a language's full name for the sub-command (i.e. `wasmer-pack javascript`) and providing aliases with its abbreviated name (i.e. you can also run `wasmer-pack js`).
