### PR TITLE
Fix the path used when importing a JavaScript library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2320,7 +2320,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasi-executable"
+name = "wasi_executable"
 version = "0.0.0"
 dependencies = [
  "anyhow",

--- a/crates/testing/src/autodiscover.rs
+++ b/crates/testing/src/autodiscover.rs
@@ -155,6 +155,7 @@ fn setup_python(crate_dir: &Path, generated_bindings: &Path) -> Result<(), Error
         cmd.arg("install")
             .arg("--sync")
             .arg("--no-interaction")
+            .arg("--quiet")
             .arg("--no-root");
         tracing::info!(?cmd, "Installing dependencies");
         let status = cmd

--- a/crates/wasmer-pack/src/js/mod.rs
+++ b/crates/wasmer-pack/src/js/mod.rs
@@ -17,27 +17,14 @@ use crate::{types::Command, Files, Library, Metadata, Package, SourceFile};
 const WASMER_WASI_VERSION: &str = "^1.2.2";
 
 static TEMPLATES: Lazy<Environment> = Lazy::new(|| {
-    let mut env = Environment::new();
-    env.add_template("bindings.index.js", include_str!("bindings.index.js.j2"))
-        .unwrap();
-    env.add_template(
+    compile_templates!(
+        "bindings.index.js",
         "bindings.index.d.ts",
-        include_str!("bindings.index.d.ts.j2"),
-    )
-    .unwrap();
-    env.add_template("command.d.ts", include_str!("command.d.ts.j2"))
-        .unwrap();
-    env.add_template("command.js", include_str!("command.js.j2"))
-        .unwrap();
-    env.add_template("top-level.index.js", include_str!("top-level.index.js.j2"))
-        .unwrap();
-    env.add_template(
         "top-level.index.d.ts",
-        include_str!("top-level.index.d.ts.j2"),
+        "command.d.ts",
+        "command.js",
+        "top-level.index.js",
     )
-    .unwrap();
-
-    env
 });
 
 /// Generate JavaScript bindings for a package.

--- a/crates/wasmer-pack/src/lib.rs
+++ b/crates/wasmer-pack/src/lib.rs
@@ -40,6 +40,9 @@
 #[cfg(test)]
 extern crate pretty_assertions;
 
+#[macro_use]
+mod macros;
+
 mod files;
 mod js;
 mod py;

--- a/crates/wasmer-pack/src/macros.rs
+++ b/crates/wasmer-pack/src/macros.rs
@@ -1,0 +1,15 @@
+macro_rules! compile_templates {
+    ( $($name:literal),* $(,)?) => {{
+        let mut env = Environment::new();
+
+        $(
+            env.add_template(
+                $name,
+                include_str!(concat!($name, ".j2")),
+            )
+            .expect(concat!("Unable to add template, ", $name));
+        )*
+
+        env
+    }}
+}

--- a/crates/wasmer-pack/src/py/mod.rs
+++ b/crates/wasmer-pack/src/py/mod.rs
@@ -13,26 +13,12 @@ use crate::{
 };
 
 static TEMPLATES: Lazy<Environment> = Lazy::new(|| {
-    let mut env = Environment::new();
-    env.add_template(
+    compile_templates!(
         "bindings.__init__.py",
-        include_str!("bindings.__init__.py.j2"),
-    )
-    .unwrap();
-    env.add_template(
         "top_level.__init__.py",
-        include_str!("top_level.__init__.py.j2"),
-    )
-    .unwrap();
-    env.add_template("MANIFEST.in", include_str!("MANIFEST.in.j2"))
-        .unwrap();
-    env.add_template(
+        "MANIFEST.in",
         "commands.__init__.py",
-        include_str!("commands.__init__.py.j2"),
     )
-    .unwrap();
-
-    env
 });
 
 /// Generate Python bindings.

--- a/examples/wasi-executable/Cargo.toml
+++ b/examples/wasi-executable/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
-name = "wasi-executable"
+# Note: We use "_" instead of "-" to test https://github.com/wasmerio/wasmer-pack/issues/98
+name = "wasi_executable"
 version = "0.0.0"
 description = "A basic WASI executable."
 edition = "2021"


### PR DESCRIPTION
*(note: this requires the integration tests from #114)*

## Description

Fixes #98.

## Context

See #98 for more context and steps to reproduce.

## Checklist

- Is this a user-facing change? If so, update [`CHANGELOG.md`](https://github.com/wasmerio/wasmer-pack/blob/master/CHANGELOG.md)
