### PR TITLE
Add description to generated packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ change, where applicable.
   and not just `wasmer/wasmer-pack`
   ([#124](https://github.com/wasmerio/wasmer-pack/pull/124))
 
+- Added description field to package.json for javascript packages, and
+  pyproject.toml for python projects..
+  ([#128](1https://github.com/wasmerio/wasmer-pack/pull/128))
+
 ## [0.7.0] - 2023-02-10
 
 ### 💥 Breaking Changes 💥

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2462,6 +2462,7 @@ dependencies = [
  "once_cell",
  "pretty_assertions",
  "serde",
+ "serde_cbor",
  "serde_json",
  "toml 0.5.11",
  "wai-bindgen-gen-core",

--- a/crates/wasmer-pack/Cargo.toml
+++ b/crates/wasmer-pack/Cargo.toml
@@ -18,6 +18,7 @@ heck = "0.4.0"
 minijinja = "0.23.0"
 once_cell = "1.14.0"
 serde = { version = "1.0.143", features = ["derive"] }
+serde_cbor = "0.11.2"
 serde_json = "1.0.83"
 toml = "0.5.9"
 wai-bindgen-gen-core = "0.2.1"

--- a/crates/wasmer-pack/src/js/mod.rs
+++ b/crates/wasmer-pack/src/js/mod.rs
@@ -266,12 +266,18 @@ fn generate_package_json(needs_wasi: bool, metadata: &Metadata) -> SourceFile {
         serde_json::json!({})
     };
 
+    let description = match &metadata.description {
+        Some(description) => description.clone(),
+        None => "".to_string(),
+    };
+
     let package_json = serde_json::json!({
         "name": metadata.package_name.javascript_package(),
         "version": &metadata.version,
         "main": format!("src/index.js"),
         "types": format!("src/index.d.ts"),
         "type": "commonjs",
+        "description": description,
         "dependencies": dependencies,
     });
 


### PR DESCRIPTION
## Description
Current state: `package.json` (for javascript projects) and `pyptoject.toml` (for python projects)
don't have a `description` field. This PR adds the field to those files.


_Note: I added a function `get_description_from_webc_manifest` to `wasmer-pack/pirita.rs`. This is very
similar to the [`get_package_name_from_manifest`](https://github.com/wasmerio/pirita/blob/4c0f733bc19a95cfaab2e2d8ac9a1e5b25babc76/crates/webc/src/v1/mod.rs#L2181) function in webc crate, and should probably belong there. If so, I need guidance moving it there._
## Context
While trying to publish a python package generated by wasmer-pack to pypi, I ran into an error from
twine.
```
ERROR    `long_description` has syntax errors in markup and would not be rendered on PyPI.
         No content rendered from RST source.
WARNING  `long_description_content_type` missing. defaulting to `text/x-rst`.
Checking dist/polyvalid-0.1.4.tar.gz: PASSED with warnings
WARNING  `long_description_content_type` missing. defaulting to `text/x-rst`.
WARNING  `long_description` missing.
```
This was solved when I added the `description` and `readme` fields to my pyproject.toml.

## Checklist

- [x] Is this a user-facing change? If so, update [`CHANGELOG.md`](https://github.com/wasmerio/wasmer-pack/blob/master/CHANGELOG.md)
