### PR TITLE
Allow specifying packages with `.` in their names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: install
-          args: cargo-wasmer --verbose --debug --version '^0.4'
+          args: cargo-wasmer --verbose --debug --version '^0.4' --locked
       - name: Type Checking
         uses: actions-rs/cargo@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ change, where applicable.
 
 ## [Unreleased] - ReleaseDate
 
+- Allow packages with `.` in their names. This is useful for packages
+  `my-website.com`. Internally, the `.` is converted into a `-` to
+  make it a valid binding name.
+
 ### Added
 - Added ability to pass in a user-specified name for the generated
   bindings. This can be done by passing in the `--name` flag in the

--- a/crates/wasmer-pack/src/types.rs
+++ b/crates/wasmer-pack/src/types.rs
@@ -219,11 +219,10 @@ fn parse_identifier(s: &str) -> Result<String, Error> {
     );
     anyhow::ensure!(
         s.chars()
-            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_')),
-        "Identifiers can only contain '-', '_', ascii numbers, and letters"
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.')),
+        "Identifiers can only contain '-', '_', '.', ascii numbers, and letters"
     );
-
-    Ok(s.to_string())
+    Ok(s.replace('.', "-"))
 }
 
 /// Information about the [`Package`] being generated.


### PR DESCRIPTION
this is done by internally replacing all the `.` with `-`.